### PR TITLE
Dockerfile: use rake gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Gauntlt
+RUN gem install rake
 RUN gem install ffi -v 1.9.18
 RUN gem install gauntlt --no-rdoc --no-ri
 


### PR DESCRIPTION
gem install gauntlt was failing using system rake
Switch to using fresh rake from gem

This is the error I was getting:
```sh-session
Step 6/20 : RUN gem install gauntlt --no-rdoc --no-ri
 ---> Running in f1558dc24cf9
Successfully installed builder-3.2.3
Successfully installed diff-lcs-1.3
Successfully installed multi_json-1.13.1
Building native extensions.  This could take a while...
Successfully installed gherkin-2.12.2
Successfully installed multi_test-0.1.2
Successfully installed cucumber-1.3.20
Building native extensions.  This could take a while...
ERROR:  Error installing gauntlt:


    current directory: /var/lib/gems/2.3.0/gems/childprocess-1.0.1/ext                                                                                                             
/usr/bin/ruby2.3 mkrf_conf.rb                                                                                                                                                      

current directory: /var/lib/gems/2.3.0/gems/childprocess-1.0.1/ext                                                                                                                 
/usr/bin/ruby2.3 -rubygems /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/rake RUBYARCHDIR=/var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/childprocess-1.0.1 RUBYLIBDIR=/var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/childprocess-1.0.1
/usr/bin/ruby2.3: No such file or directory -- /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/rake (LoadError)

rake failed, exit code 1

Gem files will remain installed in /var/lib/gems/2.3.0/gems/childprocess-1.0.1 for inspection.
Results logged to /var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/childprocess-1.0.1/gem_make.out
The command '/bin/sh -c gem install gauntlt --no-rdoc --no-ri' returned a non-zero code: 1
Makefile:4: recipe for target 'build' failed
make: *** [build] Error 1
```