### PR TITLE
Fixed image building problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
-FROM ubuntu:16.04
-MAINTAINER james@gauntlt.org
+FROM ubuntu:18.04
+LABEL maintainer=james@gauntlt.org
 
 ARG ARACHNI_VERSION=arachni-1.5.1-0.5.12
 
 # Install Ruby and other OS stuff
 RUN apt-get update && \
     apt-get install -y build-essential \
+      apt-utils \
       bzip2 \
       ca-certificates \
       curl \
       gcc \
       git \
-      libcurl3 \
+      libcurl4 \
       libcurl4-openssl-dev \
       wget \
       zlib1g-dev \


### PR DESCRIPTION
I found this problem while I was creating the Docker image:

```
Step 7/21 : RUN gem install gauntlt --no-rdoc --no-ri
 ---> Running in e9f499f67a38
!    The 'trollop' gem has been deprecated and has been replaced by 'optimist'.
!    See: https://rubygems.org/gems/optimist
!    And: https://github.com/ManageIQ/optimist
Successfully installed trollop-2.9.10
Successfully installed mini_portile2-2.4.0
Building native extensions.  This could take a while...
ERROR:  Error installing gauntlt:
	childprocess requires Ruby version >= 2.4.0.
Successfully installed nokogiri-1.10.10
Successfully installed rspec-support-3.10.0
Successfully installed diff-lcs-1.4.4
Successfully installed rspec-expectations-3.10.0
The command '/bin/sh -c gem install gauntlt --no-rdoc --no-ri' returned a non-zero code: 1
Makefile:4: recipe for target 'build' failed
make: *** [build] Error 1
```

I easily fixed just by upgrading the **Ubuntu** version from `16.04` to `18.04` (I tried to `20.04` but it seemed harder so I left it like this). `libcurl` was required to be upgraded to, and installing apt-utils avoid the message `debconf: delaying package configuration, since apt-utils is not installed` that appeared several times during the installation.

Fixes #8 
Fixes #18 