### PR TITLE
use system libffi (fixes arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN apt-get update && \
       python3-pip \
       ruby \
       ruby-dev \
-      ruby-bundler && \
-    rm -rf /var/lib/apt/lists/*
+      ruby-bundler
 
 # Install Gauntlt
 RUN gem install rake
@@ -43,10 +42,8 @@ RUN wget https://github.com/Arachni/arachni/releases/download/v1.5.1/${ARACHNI_V
     ln -s /usr/local/${ARACHNI_VERSION}/bin/* /usr/local/bin/
 
 # Nikto
-RUN apt-get update && \
-    apt-get install -y libtimedate-perl \
-      libnet-ssleay-perl && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y libtimedate-perl \
+      libnet-ssleay-perl
 
 RUN git clone --depth=1 https://github.com/sullo/nikto.git && \
     cd nikto/program && \
@@ -73,12 +70,14 @@ RUN tar xvfz dirb222.tar.gz > /dev/null && \
 ENV DIRB_WORDLISTS /opt/dirb222/wordlists
 
 # nmap
-RUN apt-get update && \
-    apt-get install -y nmap && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y nmap
 
 # sslyze
 RUN pip install sslyze
 ENV SSLYZE_PATH /usr/local/bin/sslyze
+
+# cleanup downloaded debs & repo lists
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "/usr/local/bin/gauntlt" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
       libfontconfig \
       libxml2-dev \
       libxslt1-dev \
+      libffi-dev \
       make \
       python3-pip \
       ruby \


### PR DESCRIPTION
This is not a complete fix for arm, but it does get past the immediate problem of the ffi gem failing to install, as detailed in #24.

I also changed it to only fetch repo information (apt-get update) once at the beginning, and only clean once at the end.  This saves dozens of megabytes and a few seconds to a few minutes of build time, depending on your connection speed.